### PR TITLE
Adjust conditionals to work for return vectors

### DIFF
--- a/pkg/R/centrality.edgelist.r
+++ b/pkg/R/centrality.edgelist.r
@@ -66,7 +66,7 @@ function (terms, apply.to, data.path, max.terms=20)
       ## chooses character vector as data type, which requires
       ## other selection operators than use below. Make sure that
       ## he same subsetting can be used in every case.
-      if (class(value)=="character") {
+      if ("character" %in% class(value)) {
           value <- matrix(value, nrow=1)
       }
 

--- a/pkg/R/extract.commnet.r
+++ b/pkg/R/extract.commnet.r
@@ -12,7 +12,8 @@ extract.commnet <- function (forest, terms, apply.to, data.path) {
         if (apply.to == "content") {
             net <- createedges(forest, contentfilter = terms[i])
         }
-        if (is.na(net) || is.null(net))
+
+        if (any(is.na(net)) || is.null(net))
           next
 
         if (dim(net)[1] > 0) {


### PR DESCRIPTION
In recent versions of R, some of snatm's conditionals cause an error because the functions class() and is.na() return a vector instead of a single boolean value for the given input.

Adjust these statements to iterate the return vector to find the desired class attribute and to check for any missing values in the given vector, respectively.